### PR TITLE
Scaling Screenshot Lightbox

### DIFF
--- a/report-template/css/style.css
+++ b/report-template/css/style.css
@@ -449,6 +449,8 @@ input[type='text']:focus {
 }
 
 #lightbox img {
+    max-height: 100%;
+    max-width: 100%;
     border: none;
 }
 

--- a/report-template/js/lightbox.js
+++ b/report-template/js/lightbox.js
@@ -213,12 +213,18 @@ function showLightbox(objLink)
 		// and the image placed outside the viewport
 		var lightboxTop = arrayPageScroll[1] + ((arrayPageSize[3] - 35 - imgPreload.height) / 2);
 		var lightboxLeft = ((arrayPageSize[0] - 20 - imgPreload.width) / 2);
-		
-		objLightbox.style.top = (lightboxTop < 0) ? "0px" : lightboxTop + "px";
-		objLightbox.style.left = (lightboxLeft < 0) ? "0px" : lightboxLeft + "px";
 
+        objLightbox.style.top = (lightboxTop < 0) ? "0px" : lightboxTop + "px";
 
-		objLightboxDetails.style.width = imgPreload.width + 'px';
+        if(imgPreload.width > arrayPageSize[3]) {
+            objLightbox.style.width = '95%';
+            objLightbox.style.marginLeft = 'auto';
+            objLightbox.style.marginRight = 'auto';
+        }else {
+            objLightbox.style.width = imgPreload.width + 'px';
+        }
+        objLightboxDetails.style.width = '100%';
+        objLightbox.style.maxWidth = imgPreload.width + 'px';
 		
 		if(objLink.getAttribute('title')){
 			objCaption.style.display = 'block';
@@ -374,7 +380,7 @@ function initLightbox()
 	var objLightbox = document.createElement("div");
 	objLightbox.setAttribute('id','lightbox');
 	objLightbox.style.display = 'none';
-	objLightbox.style.position = 'absolute';
+	objLightbox.style.position = 'relative';
 	objLightbox.style.zIndex = '100';	
 	objBody.insertBefore(objLightbox, objOverlay.nextSibling);
 	


### PR DESCRIPTION
_Sorry for the failed pull request. I had some problems with the merged update in git history. So here is the proper one._

Image displayed in magnified lightbox is now centered and scaled proportionally to monitor width. The full-size image can be accessed through the direct link to the img anyway.

**Before:**
![before](https://cloud.githubusercontent.com/assets/13271254/11369979/c102bcf8-92c1-11e5-958f-89da5243cac5.png)
**After:**
![after](https://cloud.githubusercontent.com/assets/13271254/11369984/c6ebb9f8-92c1-11e5-96a3-982913a47c1a.png)


