### PR TITLE
Tidying while reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ html-report
  [ ![Download Nightly](https://api.bintray.com/packages/gauge/html-report/Nightly/images/download.svg) ](https://bintray.com/gauge/html-report/Nightly/_latestVersion)
 
 
-This is the [html-report plugin](http://getgauge.io/documentation/user/current/plugins/README.html) for [gauge](http://getgauge.io).
+This is the [html-report plugin](http://getgauge.io/documentation/user/current/plugins/html_report_plugin.html) for [gauge](http://getgauge.io).
 
 Install through Gauge
 ---------------------
-````
+```
 gauge --install html-report
-````
+```
 
 * Installing specific version
 ```
@@ -31,50 +31,50 @@ Build from Source
 
 ### Compiling
 
-````
+```
 go run build/make.go
-````
+```
 
-For cross platform compilation
+For cross-platform compilation
 
-````
+```
 go run build/make.go --all-platforms
-````
+```
 
 ### Installing
 After compilation
 
-````
+```
 go run build/make.go --install
-````
+```
 
 Installing to a CUSTOM_LOCATION
 
-````
+```
 go run build/make.go --install --plugin-prefix CUSTOM_LOCATION
-````
+```
 
 ### Creating distributable
 
 Note: Run after compiling
 
-````
+```
 go run build/make.go --distro
-````
+```
 
-For distributable across platforms os, windows and linux for bith x86 and x86_64
+For distributable across platforms: Windows and Linux for both x86 and x86_64
 
-````
+```
 go run build/make.go --distro --all-platforms
-````
+```
 
-New distribution details need to be updated in the html-report-install.json file in  [gauge plugin repository](https://github.com/getgauge/gauge-repository) for a new verison update.
+New distribution details need to be updated in the `html-report-install.json` file in the [gauge plugin repository](https://github.com/getgauge/gauge-repository) for a new version update.
 
 License
 -------
 
 ![GNU Public License version 3.0](http://www.gnu.org/graphics/gplv3-127x51.png)
-Html-Report is released under [GNU Public License version 3.0](http://www.gnu.org/licenses/gpl-3.0.txt)
+`html-report` is released under [GNU Public License version 3.0](http://www.gnu.org/licenses/gpl-3.0.txt)
 
 Copyright
 ---------


### PR DESCRIPTION
Fix documentation URL.

Code block fences are three ticks (```). Four ticks mess up at least
Vim's highlighting.