### PR TITLE
Fix code blocks from being escaped

### DIFF
--- a/generator/generate_test.go
+++ b/generator/generate_test.go
@@ -235,6 +235,8 @@ var wSpecCommentsWithoutTableTag = `<span></span>
 <span><pre><code>gauge specs</code></pre></span>
 <span></span>`
 
+var wSpecCommentsWithCodeBlock = `<span><pre><code>{&#34;prop&#34;:&#34;value&#34;}</code></pre></span>`
+
 var wScenarioContainerStartPassDiv = `<div class='scenario-container passed'>`
 var wScenarioContainerStartFailDiv = `<div class='scenario-container failed'>`
 var wScenarioContainerStartSkipDiv = `<div class='scenario-container skipped'>`
@@ -361,6 +363,10 @@ var stepWithBracketsInFragment = &step{
 	},
 }
 
+var stepWithCodeBlock = &spec{
+	CommentsBeforeTable: []string{`    {"prop":"value"}`},
+}
+
 var stepWithFileParam = &step{
 	Fragments: []*fragment{
 		{FragmentKind: textFragmentKind, Text: "Say "},
@@ -429,6 +435,7 @@ var reportGenTests = []reportGenTest{
 	{"generate div for tags", tagsDiv, &specHeader{Tags: []string{"tag1", "tag2"}}, wTagsDiv},
 	{"generate spec comments with data table (if present)", specCommentsAndTableTag, newSpec(true), wSpecCommentsWithTableTag},
 	{"generate spec comments without data table", specCommentsAndTableTag, newSpec(false), wSpecCommentsWithoutTableTag},
+	{"generate spec comments with code block", specCommentsAndTableTag, stepWithCodeBlock, wSpecCommentsWithCodeBlock},
 	{"generate passing scenario container", scenarioContainerStartDiv, &scenario{ExecStatus: pass, TableRowIndex: -1}, wScenarioContainerStartPassDiv},
 	{"generate failed scenario container", scenarioContainerStartDiv, &scenario{ExecStatus: fail, TableRowIndex: -1}, wScenarioContainerStartFailDiv},
 	{"generate skipped scenario container", scenarioContainerStartDiv, &scenario{ExecStatus: skip, TableRowIndex: -1}, wScenarioContainerStartSkipDiv},

--- a/generator/templates.go
+++ b/generator/templates.go
@@ -141,7 +141,7 @@ const tagsDiv = `{{if .Tags}}<div class="tags scenario_tags contentSection">
 const messageDiv = `{{if .Messages}}<div class="message-container">
   <i class="fa fa-minus-square" aria-hidden="true"></i>
   <div class="messages">
-    {{range .Messages}}<div class="step-message">{{. | escapeHTML | encodeNewLine | parseMarkdown }} </div>{{end}}
+    {{range .Messages}}<div class="step-message">{{. | encodeNewLine | parseMarkdown | sanitize}} </div>{{end}}
   </div>
 </div>{{end}}`
 
@@ -185,7 +185,7 @@ const scenarioHeaderStartDiv = `<div class="scenario-head">
   <h3 class="head borderBottom">{{.Heading | escapeHTML }}</h3>
   <span class="time">{{.ExecTime}}</span>`
 
-const specCommentsAndTableTag = `{{range .CommentsBeforeTable}}<span>{{. | escapeHTML| parseMarkdown}}</span>{{end}}
+const specCommentsAndTableTag = `{{range .CommentsBeforeTable}}<span>{{. | parseMarkdown | sanitize}}</span>{{end}}
 {{if .Table}}<table class="data-table">
   <tr>
     {{range .Table.Headers}}<th>{{. | escapeHTML }}</th>{{end}}
@@ -201,7 +201,7 @@ const specCommentsAndTableTag = `{{range .CommentsBeforeTable}}<span>{{. | escap
     {{end}}
   </tbody>
 </table>{{end}}
-{{range .CommentsAfterTable}}<span>{{. | escapeHTML | parseMarkdown }}</span>{{end}}`
+{{range .CommentsAfterTable}}<span>{{. | parseMarkdown | sanitize}}</span>{{end}}`
 
 const htmlPageStartTag = `<!doctype html>
 <html><head>
@@ -319,7 +319,7 @@ const conceptSpan = `<i class="fa fa-plus-square" aria-hidden="true"></i>`
 
 const contextOrTeardownStartDiv = `<div class='context-step'>`
 
-const commentSpan = `<span>{{.Text | escapeHTML | parseMarkdown}}</span>`
+const commentSpan = `<span>{{.Text | parseMarkdown | sanitize}}</span>`
 
 const conceptStepsStartDiv = `<div class='concept-steps'>`
 
@@ -337,5 +337,5 @@ const htmlPageEndWithJS = `
   <script src="{{.BasePath}}js/search_index.js" type="text/javascript"></script>
   <script src="{{.BasePath}}js/main.js" type="text/javascript"></script>
   </body>
-</html>  
+</html>
 `


### PR DESCRIPTION
These changes fix the code blocks being escaped but also allows some html tags of being used.

Related to issue: #128 