### PR TITLE
CSS bug fix

### DIFF
--- a/themes/default/assets/css/style.css
+++ b/themes/default/assets/css/style.css
@@ -1028,7 +1028,7 @@ footer p {
     }
 
     .specifications .sidebar {
-        width: 350px;
+        min-width: 350px;
     }
 
     .details .content {


### PR DESCRIPTION
The left sidebar is collapsed when a custom message inside a step is wide (for example, I realised this when printing the content of a parsed and minified XML message). When setting CSS property `min-width` instead of `width`, we can avoid this.