### PR TITLE
Removed "--" symbols before keyword "install"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,18 @@ This is the [html-report plugin](http://getgauge.io/documentation/user/current/p
 Install through Gauge
 ---------------------
 ```
-gauge --install html-report
+gauge install html-report
 ```
 
 * Installing specific version
 ```
-gauge --install html-report --plugin-version 2.1.0
+gauge install html-report --plugin-version 2.1.0
 ```
 
 ### Offline installation
 * Download the plugin from [Releases](https://github.com/getgauge/html-report/releases)
 ```
-gauge --install html-report --file html-report-2.1.0-linux.x86_64.zip
+gauge install html-report --file html-report-2.1.0-linux.x86_64.zip
 ```
 
 Build from Source
@@ -48,13 +48,13 @@ go run build/make.go --all-platforms
 After compilation
 
 ```
-go run build/make.go --install
+go run build/make.go install
 ```
 
 Installing to a CUSTOM_LOCATION
 
 ```
-go run build/make.go --install --plugin-prefix CUSTOM_LOCATION
+go run build/make.go install --plugin-prefix CUSTOM_LOCATION
 ```
 
 ### Creating distributable

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ gauge install html-report
 
 * Installing specific version
 ```
-gauge install html-report --plugin-version 2.1.0
+gauge install html-report --version 2.1.0
 ```
 
 ### Offline installation
@@ -48,13 +48,13 @@ go run build/make.go --all-platforms
 After compilation
 
 ```
-go run build/make.go install
+go run build/make.go --install
 ```
 
 Installing to a CUSTOM_LOCATION
 
 ```
-go run build/make.go install --plugin-prefix CUSTOM_LOCATION
+go run build/make.go --install --plugin-prefix CUSTOM_LOCATION
 ```
 
 ### Creating distributable


### PR DESCRIPTION
According to gitter conversation keyword "--install" was removed in the latest version of gauge.
