### PR TITLE
fix: allow one click access for html-report (#286)

### DIFF
--- a/htmlReport.go
+++ b/htmlReport.go
@@ -28,7 +28,7 @@ const (
 	setupAction     = "setup"
 	executionAction = "execution"
 	pluginActionEnv = "html-report_action"
-	timeFormat      = "2006-01-02 15.04.05"
+	timeFormat      = "2006-01-02_15.04.05"
 )
 
 type nameGenerator interface {

--- a/plugin.json
+++ b/plugin.json
@@ -28,5 +28,5 @@
     "scope": [
         "Execution"
     ],
-    "version": "4.1.3"
+    "version": "4.1.4"
 }


### PR DESCRIPTION
Removing space character from timestamp based path to allow one click (cmd+click) access on the terminal of vs-code on macOS.

issue: https://github.com/getgauge/html-report/issues/286