### PR TITLE
allow grpc's MaxMsgRecvSize to be set via a config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Setup go 1.16
-        uses: actions/setup-go@v1
+      - name: Setup go 1.19
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.16
+          go-version: '>=1.19.0'
 
       - name: build
         run: |

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,9 +11,9 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
-      - name: Setup go 1.16
-        uses: actions/setup-go@v1
+      - name: Setup go 1.19
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.16
+          go-version: '>=1.19.0'
 
       - name: Download packages
         run: |

--- a/env/env.go
+++ b/env/env.go
@@ -26,6 +26,7 @@ const (
 	SaveExecutionResult         = "save_execution_result"
 	pluginKillTimeout           = "plugin_kill_timeout"
 	gaugeMinifyReports          = "gauge_minify_reports"
+	gaugeMaxMessageSize         = "gauge_max_message_size"
 )
 
 func GetCurrentExecutableDir() (string, string) {
@@ -98,6 +99,15 @@ func ShouldMinifyReports() bool {
 func isEnvSet(envName string) bool {
 	envValue := os.Getenv(envName)
 	return strings.ToLower(envValue) == "true"
+}
+
+func GetMaxMessageSize() int {
+	m := os.Getenv(gaugeMaxMessageSize)
+	r, err := strconv.Atoi(m)
+	if err != nil {
+		return 1024
+	}
+	return r
 }
 
 // PluginKillTimeout returns the plugin_kill_timeout in seconds

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -1,0 +1,29 @@
+package env
+
+import "testing"
+
+func TestMaxRecvMsgSize(t *testing.T) {
+	t.Run("empty value should return default", func(t *testing.T) {
+		t.Setenv(gaugeMaxMessageSize, "")
+		v := GetMaxMessageSize()
+		if v != 1024 {
+			t.Errorf("Expected 1024, got %d", v)
+		}
+	})
+
+	t.Run("non-numeric should return default", func(t *testing.T) {
+		t.Setenv(gaugeMaxMessageSize, "abcd")
+		v := GetMaxMessageSize()
+		if v != 1024 {
+			t.Errorf("Expected 1024, got %d", v)
+		}
+	})
+
+	t.Run("numeric should return set value", func(t *testing.T) {
+		t.Setenv(gaugeMaxMessageSize, "2048")
+		v := GetMaxMessageSize()
+		if v != 2048 {
+			t.Errorf("Expected 2048, got %d", v)
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -58,7 +58,9 @@ func main() {
 		if err != nil {
 			logger.Fatalf("failed to start server.")
 		}
-		server := grpc.NewServer(grpc.MaxRecvMsgSize(1024 * 1024 * 1024))
+		mSize := env.GetMaxMessageSize()
+		logger.Debugf("Setting MaxRecvMsgSize = %d MB", mSize)
+		server := grpc.NewServer(grpc.MaxRecvMsgSize(mSize * 1024 * 1024))
 		h := &handler{server: server}
 		gauge_messages.RegisterReporterServer(server, h)
 		logger.Infof("Listening on port:%d", l.Addr().(*net.TCPAddr).Port)

--- a/plugin.json
+++ b/plugin.json
@@ -28,5 +28,5 @@
     "scope": [
         "Execution"
     ],
-    "version": "4.1.5"
+    "version": "4.2.0"
 }


### PR DESCRIPTION
- add ability to set MaxRecvMsgSize via config, #2305
- bump version -> 4.2.0

Allows users to set `gauge_max_message_size` property / env variable

For #2305