### PR TITLE
Fix security vulnerabilities by upgrading to Go 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/getgauge/html-report
 
-go 1.26.2
+go 1.26
 
 require (
 	github.com/documize/html-diff v0.0.0-20160503140253-f61c192c7796

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/getgauge/html-report
 
-go 1.26
+go 1.26.2
 
 require (
 	github.com/documize/html-diff v0.0.0-20160503140253-f61c192c7796

--- a/plugin.json
+++ b/plugin.json
@@ -28,5 +28,5 @@
     "scope": [
         "Execution"
     ],
-    "version": "4.4.3"
+    "version": "4.4.4"
 }


### PR DESCRIPTION
- Fixes CVE-2026-32281 (medium) in crypto/x509
- Fixes CVE-2026-32280 (high) in crypto/x509
- Fixes CVE-2026-33810 (high) in crypto/x509
- Fixes CVE-2026-32289 (medium) in html/template

All vulnerabilities will be resolved by upgrading from Go 1.26 to 1.26.2